### PR TITLE
Implements an abortOnUncaught flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ var myLogger = {
 var onError = uncaughtHandler({
     logger: myLogger,
     prefix: 'some string prefix ',
+    abortOnUncaught: true, // opt into aborting on uncaught
     backupFile: '/path/to/uncaught-handler.log',
     gracefulShutdown: function (callback) {
         // perform some graceful shutdown here.
@@ -50,6 +51,7 @@ uncaught-exception/uncaught := (options: {
     },
     prefix?: String,
     backupFile?: String,
+    abortOnUncaught?: Boolean,
     loggerTimeout?: Number,
     shutdownTimeout?: Number,
     gracefulShutdown?: (Callback) => void,
@@ -107,6 +109,14 @@ You may also pass the string literal `"stdout"` or `"stderr"` as
   asynchronous. i.e. `node foo.js | tee file` will involve
   asynchronous writing to the `backupFile`.
 
+#### `options.abortOnUncaught`
+
+If `options.abortOnUncaught` is set to `true` the uncaught handler
+will call graceful shutdown and `process.abort()` for you.
+
+If this is set to `undefined` or `false` the uncaught handler
+will not call graceful shutdown and it will not call process abort
+
 #### `options.loggerTimeout`
 
 The `uncaughtHandler` will assume that your logger might fail or
@@ -121,6 +131,9 @@ The `uncaught-exception` module supports doing a graceful
   shutdown. Normally when an uncaught exception happens you
   want to close any servers that are open and wait for all
   sockets to exit cleanly.
+
+This function only gets called if `abortOnUncaught` is set to
+`true`.
 
 Ideally you want to empty the event loop and do a full graceful
   shutdown.
@@ -143,6 +156,9 @@ The default timeout is 30 seconds, you can pass `shutdownTimeout`
 
 You can specify your own `preAbort` handler that **MUST** be
   a synchronous function.
+
+This function only gets called if `abortOnUncaught` is set to
+`true`.
 
 The main use case is to invoke your own exit strategy instead of
   the default exit strategy which is calling `process.abort()`

--- a/docs.mli
+++ b/docs.mli
@@ -4,6 +4,7 @@ uncaught-exception/uncaught := (options: {
     },
     prefix?: String,
     backupFile?: "stdout" | "stderr" | String,
+    abortOnUncaught?: Boolean,
     loggerTimeout?: Number,
     shutdownTimeout?: Number,
     gracefulShutdown?: (Callback) => void,

--- a/test/index.js
+++ b/test/index.js
@@ -27,7 +27,7 @@ test('check coverage', function t(assert) {
 function getCoverage(cb) {
     var cmd = path.join(__dirname, '..', 'node_modules',
         '.bin', 'istanbul');
-    exec(cmd + ' check-coverage --branches=100', {
+    exec(cmd + ' check-coverage --branches=100 --lines=100', {
         cwd: path.join(__dirname, '..')
     }, onCmd);
 

--- a/test/lib/event-reporter.js
+++ b/test/lib/event-reporter.js
@@ -11,6 +11,9 @@ var EVENTS = [
     'reportPreLogging',
     'reportLogging',
     'reportPostLogging',
+    'reportPreGracefulShutdown',
+    'reportShutdown',
+    'reportPostGracefulShutdown',
     'markTransition'
 ];
 
@@ -31,6 +34,10 @@ function createStateMachine(a) {
 
     return UncaughtMemoryReporter.prototype.createStateMachine
         .apply(this, arguments);
+};
+
+EventReporter.prototype.getAllState = function getAllState() {
+    return {};
 };
 
 EVENTS.forEach(function addMethod(ev) {

--- a/test/lib/event-reporter.js
+++ b/test/lib/event-reporter.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+
+var UncaughtMemoryReporter =
+    require('../../uncaught/structures.js').UncaughtMemoryReporter;
+
+var EVENTS = [
+    'reportConfig',
+    'reportPreLogging',
+    'reportLogging',
+    'reportPostLogging',
+    'markTransition'
+];
+
+module.exports = EventReporter;
+
+function EventReporter() {
+    if (!(this instanceof EventReporter)) {
+        return new EventReporter();
+    }
+
+    EventEmitter.call(this);
+}
+util.inherits(EventReporter, EventEmitter);
+
+EventReporter.prototype.createStateMachine =
+function createStateMachine(a) {
+    this.emit('createStateMachine', a);
+
+    return UncaughtMemoryReporter.prototype.createStateMachine
+        .apply(this, arguments);
+};
+
+EVENTS.forEach(function addMethod(ev) {
+    EventReporter.prototype[ev] = function emit(a) {
+        this.emit(ev, a);
+    };
+});

--- a/test/shutdown-child.js
+++ b/test/shutdown-child.js
@@ -11,6 +11,7 @@ var process = require('process');
 var setTimeout = require('timers').setTimeout;
 
 var uncaughtException = require('../uncaught.js');
+var EventReporter = require('./lib/event-reporter.js');
 var opts = JSON.parse(process.argv[2]);
 
 if (opts.consoleLogger) {
@@ -159,7 +160,25 @@ opts.preAbort = function preAbort() {
     if (opts.throwInAbort) {
         throw new Error('bug in preAbort');
     }
+    if (opts.exitOnPreAbort) {
+        process.exit(101);
+    }
 };
+
+if (opts.exitCode && opts.abortOnUncaught === false) {
+    opts.reporter = EventReporter();
+    opts.reporter.once('reportPostLogging', function a() {
+        setTimeout(function onExit() {
+            process.exit(opts.exitCode);
+        }, 0);
+    });
+}
+
+if (opts.exitOnGracefulShutdown) {
+    opts.gracefulShutdown = function exitIt() {
+        process.exit(101);
+    };
+}
 
 if (opts.abortOnUncaught === undefined) {
     opts.abortOnUncaught = true;

--- a/test/shutdown-child.js
+++ b/test/shutdown-child.js
@@ -161,6 +161,10 @@ opts.preAbort = function preAbort() {
     }
 };
 
+if (opts.abortOnUncaught === undefined) {
+    opts.abortOnUncaught = true;
+}
+
 var onError = uncaughtException(opts);
 process.on('uncaughtException', onError);
 

--- a/test/shutdown.js
+++ b/test/shutdown.js
@@ -622,6 +622,107 @@ test('handles a shutdown + late succeed', function t(assert) {
     });
 });
 
+test('continue on exception', function t(assert) {
+    var loc = path.join(__dirname, 'backupFile.log');
+
+    spawnChild({
+        message: 'continue on exception',
+        abortOnUncaught: false,
+        consoleLogger: true,
+        exitCode: 3,
+        backupFile: loc
+    }, function onerror(err, stdout, stderr) {
+        assert.ok(err);
+        assert.equal(err.code, 3);
+
+        assert.equal(stdout.indexOf('continue on exception'), -1);
+        assert.notEqual(
+            stderr.indexOf('continue on exception'), -1);
+
+        fs.readFile(loc, function onfile(err2, buf) {
+            assert.ifError(err2);
+
+            var lines = String(buf).trim().split('\n');
+
+            assert.equal(lines.length, 1);
+            var line1 = JSON.parse(lines[0]);
+
+            assert.equal(line1.message, 'continue on exception');
+            assert.equal(line1._uncaughtType, 'exception.occurred');
+
+            fs.unlink(loc, assert.end);
+        });
+    });
+});
+
+test('continue on exception - do not call graceful', function t(assert) {
+    var loc = path.join(__dirname, 'backupFile.log');
+
+    spawnChild({
+        message: 'continue on exception',
+        abortOnUncaught: false,
+        consoleLogger: true,
+        exitOnGracefulShutdown: true,
+        exitCode: 3,
+        backupFile: loc
+    }, function onerror(err, stdout, stderr) {
+        assert.ok(err);
+        assert.equal(err.code, 3);
+
+        assert.equal(stdout.indexOf('continue on exception'), -1);
+        assert.notEqual(
+            stderr.indexOf('continue on exception'), -1);
+
+        fs.readFile(loc, function onfile(err2, buf) {
+            assert.ifError(err2);
+
+            var lines = String(buf).trim().split('\n');
+
+            assert.equal(lines.length, 1);
+            var line1 = JSON.parse(lines[0]);
+
+            assert.equal(line1.message, 'continue on exception');
+            assert.equal(line1._uncaughtType, 'exception.occurred');
+
+            fs.unlink(loc, assert.end);
+        });
+    });
+});
+
+test('continue on exception - do not call preAbort', function t(assert) {
+    var loc = path.join(__dirname, 'backupFile.log');
+
+    spawnChild({
+        message: 'continue on exception',
+        abortOnUncaught: false,
+        consoleLogger: true,
+        exitOnPreAbort: true,
+        exitCode: 3,
+        backupFile: loc
+    }, function onerror(err, stdout, stderr) {
+        assert.ok(err);
+        assert.equal(err.code, 3);
+
+        assert.equal(stdout.indexOf('continue on exception'), -1);
+        assert.notEqual(
+            stderr.indexOf('continue on exception'), -1);
+
+        fs.readFile(loc, function onfile(err2, buf) {
+            assert.ifError(err2);
+
+            var lines = String(buf).trim().split('\n');
+
+            assert.equal(lines.length, 1);
+            var line1 = JSON.parse(lines[0]);
+
+            assert.equal(line1.message, 'continue on exception');
+            assert.equal(line1._uncaughtType, 'exception.occurred');
+
+            fs.unlink(loc, assert.end);
+        });
+    });
+});
+
 test('handles writing to bad file', function t(assert) {
     var loc = path.join(__dirname, 'does', 'not', 'exist');
 

--- a/uncaught.js
+++ b/uncaught.js
@@ -32,6 +32,9 @@ function UncaughtException(options) {
     self.shutdownTimeout =
         typeof options.shutdownTimeout === 'number' ?
         options.shutdownTimeout : Constants.SHUTDOWN_TIMEOUT;
+    self.abortOnUncaught =
+        typeof options.abortOnUncaught === 'boolean' ?
+        options.abortOnUncaught : false;
 
     self.gracefulShutdown =
         typeof options.gracefulShutdown === 'function' ?

--- a/uncaught.js
+++ b/uncaught.js
@@ -42,7 +42,8 @@ function UncaughtException(options) {
     self.preAbort = typeof options.preAbort === 'function' ?
         options.preAbort : noop;
 
-    self.reporter = new structures.UncaughtMemoryReporter(self);
+    self.reporter = options.reporter ||
+        new structures.UncaughtMemoryReporter();
     self.handlers = [];
 }
 

--- a/uncaught.js
+++ b/uncaught.js
@@ -58,7 +58,7 @@ function createUncaught(options) {
     checkOptions(options);
 
     var uncaught = new UncaughtException(options);
-    uncaught.reporter.reportConfig();
+    uncaught.reporter.reportConfig(uncaught);
 
     return uncaughtListener;
 

--- a/uncaught/structures.js
+++ b/uncaught/structures.js
@@ -107,28 +107,26 @@ function UncaughtExceptionPostGracefulShutdownState(opts) {
     this.backupFileShutdownErrorLine = opts.backupFileShutdownErrorLine;
 }
 
-function UncaughtMemoryReporter(uncaught) {
+function UncaughtMemoryReporter() {
     var self = this;
-
-    self.uncaught = uncaught;
 
     self.configValue = null;
 }
 
 UncaughtMemoryReporter.prototype.reportConfig =
-function reportConfig() {
+function reportConfig(uncaught) {
     var self = this;
 
     self.configValue = new structures.UncaughtExceptionConfigValue({
-        prefix: self.uncaught.prefix,
-        backupFile: self.uncaught.backupFile,
-        loggerTimeout: self.uncaught.loggerTimeout,
-        shutdownTimeout: self.uncaught.shutdownTimeout,
-        hasGracefulShutdown: !!self.uncaught.options.gracefulShutdown,
-        hasPreAbort: !!self.uncaught.options.preAbort,
-        hasFakeFS: !!self.uncaught.options.fs,
-        hasFakeSetTimeout: !!self.uncaught.options.setTimeout,
-        hasFakeClearTimeout: !!self.uncaught.options.clearTimeout
+        prefix: uncaught.prefix,
+        backupFile: uncaught.backupFile,
+        loggerTimeout: uncaught.loggerTimeout,
+        shutdownTimeout: uncaught.shutdownTimeout,
+        hasGracefulShutdown: !!uncaught.options.gracefulShutdown,
+        hasPreAbort: !!uncaught.options.preAbort,
+        hasFakeFS: !!uncaught.options.fs,
+        hasFakeSetTimeout: !!uncaught.options.setTimeout,
+        hasFakeClearTimeout: !!uncaught.options.clearTimeout
     });
 };
 

--- a/uncaught/uncaught-handler.js
+++ b/uncaught/uncaught-handler.js
@@ -120,7 +120,10 @@ function onLoggerFatal(err) {
         self.loggerAsyncError = err;
         self.backupLog.log('logger.uncaught.exception', self.uncaughtError);
         self.backupLog.log('logger.failure', err);
+
     }
+
+    self.uncaught.reporter.reportPostLogging(self);
 
     self.handleGracefulShutdown();
 };

--- a/uncaught/uncaught-handler.js
+++ b/uncaught/uncaught-handler.js
@@ -259,6 +259,7 @@ function onDomainError(domainError) {
                 errorStack: domainError.stack,
                 currentState: currentState
             }));
+            /* istanbul ignore next: onGracefulShutdown() calls abort */
             break;
 
         /* istanbul ignore next: impossible else block */
@@ -301,6 +302,7 @@ function transition(error) {
         case Constants.PRE_GRACEFUL_SHUTDOWN_STATE:
         case Constants.GRACEFUL_SHUTDOWN_STATE:
             self.onGracefulShutdown(error);
+            /* istanbul ignore next: onGracefulShutdown() calls abort */
             break;
 
         /* istanbul ignore next: impossible else block */

--- a/uncaught/uncaught-handler.js
+++ b/uncaught/uncaught-handler.js
@@ -42,11 +42,9 @@ function handleError(error) {
     var currentDomain = self.currentDomain = domain.create();
     currentDomain.on('error', onDomainError);
 
-    currentDomain.run(handleLogError);
-
-    function handleLogError() {
+    currentDomain.run(function handleLogError() {
         self.handleLogError();
-    }
+    });
 
     function onDomainError(domainError) {
         self.onDomainError(domainError);
@@ -64,7 +62,9 @@ function handleLogError() {
 
     self.uncaught.reporter.reportPreLogging(self);
 
-    var tuple = tryCatch(invokeLoggerFatal);
+    var tuple = tryCatch(function invokeLoggerFatal() {
+        self.invokeLoggerFatal();
+    });
 
     self.loggerError = tuple[0];
     self.uncaught.reporter.reportLogging(self);
@@ -75,10 +75,6 @@ function handleLogError() {
             errorType: self.loggerError.type,
             errorStack: self.loggerError.stack
         }));
-    }
-
-    function invokeLoggerFatal() {
-        self.invokeLoggerFatal();
     }
 
     function onlogtimeout() {
@@ -140,7 +136,9 @@ function handleGracefulShutdown() {
 
     self.uncaught.reporter.reportPreGracefulShutdown(self);
 
-    var tuple = tryCatch(invokeGracefulShutdown);
+    var tuple = tryCatch(function invokeGracefulShutdown() {
+        self.invokeGracefulShutdown();
+    });
 
     self.shutdownError = tuple[0];
     self.uncaught.reporter.reportShutdown(self);
@@ -151,10 +149,6 @@ function handleGracefulShutdown() {
             errorType: self.shutdownError.type,
             errorStack: self.shutdownError.stack
         }));
-    }
-
-    function invokeGracefulShutdown() {
-        self.invokeGracefulShutdown();
     }
 
     function onshutdowntimeout() {
@@ -214,13 +208,11 @@ function internalTerminate(allState) {
 
     // try and swallow the exception, if you have an
     // exception in preAbort then you're fucked, abort().
-    tryCatch(invokePreAbort);
+    tryCatch(function invokePreAbort() {
+        preAbort(allState);
+    });
     /* istanbul ignore next: abort() is untestable */
     process.abort();
-
-    function invokePreAbort() {
-        preAbort(allState);
-    }
 };
 
 UncaughtExceptionHandler.prototype.onDomainError =

--- a/uncaught/uncaught-handler.js
+++ b/uncaught/uncaught-handler.js
@@ -132,6 +132,11 @@ UncaughtExceptionHandler.prototype.handleGracefulShutdown =
 function handleGracefulShutdown() {
     var self = this;
 
+    if (!self.uncaught.abortOnUncaught) {
+        self.currentState = Constants.POST_GRACEFUL_SHUTDOWN_STATE;
+        return self.transition();
+    }
+
     self.currentState = Constants.PRE_GRACEFUL_SHUTDOWN_STATE;
     self.timerHandles.shutdown = self.uncaught.timers.setTimeout(
         onshutdowntimeout, self.uncaught.shutdownTimeout
@@ -199,6 +204,10 @@ function onGracefulShutdown(err) {
 UncaughtExceptionHandler.prototype.handleTerminate =
 function handleTerminate() {
     var self = this;
+
+    if (!self.uncaught.abortOnUncaught) {
+        return;
+    }
 
     var allState = self.uncaught.reporter.getAllState(self);
     self.internalTerminate(allState);

--- a/uncaught/uncaught-handler.js
+++ b/uncaught/uncaught-handler.js
@@ -42,9 +42,9 @@ function handleError(error) {
     var currentDomain = self.currentDomain = domain.create();
     currentDomain.on('error', onDomainError);
 
-    currentDomain.run(function handleLogError() {
-        self.handleLogError();
-    });
+    currentDomain.enter();
+    self.handleLogError();
+    currentDomain.exit();
 
     function onDomainError(domainError) {
         self.onDomainError(domainError);


### PR DESCRIPTION
The `abortOnUncaught` exception flag will only abort() if
set to true; it defaults to false.

When set to false it will not call `gracefulShutdown()`
and will not call `preAbort()`.

In production; we currently write stats in the `gracefulShutdown()`,
so we will have to add statsd support as a first class
feature to uncaught-exception.

This PR does a few things

 - Adds the flag
 - Minor clean ups to the code
 - Fix tests to use an EventEmitter reporter
 - Update tests and add more tests.

There will be a follow up PR to add statsd.

r: @jwolski @iproctor