### PR TITLE
Log static uncaught message with meta object

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "error": "^4.1.1",
-    "json-stringify-safe": "^5.0.0",
-    "once": "^1.3.0",
-    "process": "^0.7.0"
+    "error": "^7.0.1",
+    "json-stringify-safe": "^5.0.1",
+    "once": "^1.3.2",
+    "process": "^0.11.1",
+    "xtend": "^4.0.0"
   },
   "collaborators": [
     {
@@ -26,17 +27,16 @@
     }
   ],
   "devDependencies": {
-    "assert-tap": "~0.1.4",
-    "fake-fs": "^0.4.0",
-    "istanbul": "^0.3.13",
-    "jshint": "^2.5.1",
-    "opn": "^0.1.2",
+    "assert-tap": "^0.1.4",
+    "fake-fs": "^0.5.0",
+    "istanbul": "^0.3.15",
+    "jshint": "^2.8.0",
+    "opn": "^2.0.0",
     "pre-commit": "0.0.9",
-    "tap-spec": "^0.2.0",
+    "tap-spec": "^4.0.0",
     "tape": "^4.0.0",
     "time-mock": "^0.1.2",
-    "uber-statsd-client": "1.3.2",
-    "xtend": "~2.1.1"
+    "uber-statsd-client": "1.3.2"
   },
   "scripts": {
     "test": "npm run jshint && npm run cover",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "istanbul": "^0.3.15",
     "jshint": "^2.8.0",
     "opn": "^2.0.0",
-    "pre-commit": "0.0.9",
     "tape": "^4.0.0",
     "time-mock": "^0.1.2",
     "uber-statsd-client": "1.3.2"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "error": "^7.0.1",
     "json-stringify-safe": "^5.0.1",
-    "once": "^1.3.2",
     "process": "^0.11.1",
     "xtend": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "jshint": "^2.8.0",
     "opn": "^2.0.0",
     "pre-commit": "0.0.9",
-    "tap-spec": "^4.0.0",
     "tape": "^4.0.0",
     "time-mock": "^0.1.2",
     "uber-statsd-client": "1.3.2"

--- a/test/shutdown-child.js
+++ b/test/shutdown-child.js
@@ -17,11 +17,8 @@ var opts = JSON.parse(process.argv[2]);
 
 if (opts.consoleLogger) {
     opts.logger = {
-        fatal: function fatal(message, options, cb) {
-            console.error(message, {
-                message: opts.message,
-                stack: opts.stack
-            });
+        fatal: function fatal(message, meta, cb) {
+            console.error(message, meta);
             cb();
         }
     };
@@ -29,7 +26,7 @@ if (opts.consoleLogger) {
 
 if (opts.errorLogger) {
     opts.logger = {
-        fatal: function fatal(message, options, cb) {
+        fatal: function fatal(message, meta, cb) {
             cb(new Error('oops in logger.fatal()'));
         }
     };
@@ -65,7 +62,7 @@ if (opts.thrownLogger) {
 
 if (opts.lateTimeoutLogger) {
     opts.logger = {
-        fatal: function fatal(message, options, cb) {
+        fatal: function fatal(message, meta, cb) {
             // simulate a really slow logger
             setTimeout(function delay() {
                 cb();
@@ -76,7 +73,7 @@ if (opts.lateTimeoutLogger) {
 
 if (!opts.logger) {
     opts.logger = {
-        fatal: function fatal(message, options, cb) {
+        fatal: function fatal(message, meta, cb) {
             cb();
         }
     };

--- a/test/uncaught.js
+++ b/test/uncaught.js
@@ -104,11 +104,11 @@ test('uncaughtException adds a listener', function t(assert) {
 
 test('uncaughtException logs to logger', function t(assert) {
     var logger = {
-        fatal: function fatal(message, error) {
-            assert.equal(message, 'Uncaught Exception: ');
-            assert.ok(error);
-            assert.ok(error.stack);
-            assert.equal(error.message, 'test error');
+        fatal: function fatal(message, meta) {
+            assert.equal(message, 'Uncaught Exception');
+            assert.ok(meta.error);
+            assert.ok(meta.error.stack);
+            assert.equal(meta.error.message, 'test error');
 
             remove();
             assert.end();
@@ -124,14 +124,14 @@ test('uncaughtException logs to logger', function t(assert) {
     });
 });
 
-test('uncaughtException prefix', function t(assert) {
+test('uncaughtException meta', function t(assert) {
     var logger = {
-        fatal: function fatal(message, error) {
-            assert.equal(message,
-                'some-server: Uncaught Exception: ');
-            assert.ok(error);
-            assert.ok(error.stack);
-            assert.equal(error.message, 'error test');
+        fatal: function fatal(message, meta) {
+            assert.equal(message, 'Uncaught Exception');
+            assert.ok(meta.error);
+            assert.ok(meta.error.stack);
+            assert.equal(meta.error.message, 'error test');
+            assert.equal(meta.testProp, 'testVal');
 
             remove();
             assert.end();
@@ -140,7 +140,9 @@ test('uncaughtException prefix', function t(assert) {
 
     var remove = uncaught({
         logger: logger,
-        prefix: 'some-server: '
+        meta: {
+            testProp: 'testVal'
+        }
     });
 
     process.nextTick(function throwIt() {
@@ -150,12 +152,13 @@ test('uncaughtException prefix', function t(assert) {
 
 test('handles throwing strings', function t(assert) {
     var logger = {
-        fatal: function fatal(message, error) {
+        fatal: function fatal(message, meta) {
             assert.equal(message,
-                'some-server: Uncaught Exception: ');
-            assert.ok(error);
-            assert.ok(error.stack);
-            assert.equal(error.message, 'error test');
+                'Uncaught Exception');
+            assert.ok(meta.error);
+            assert.ok(meta.error.stack);
+            assert.equal(meta.error.message, 'error test');
+            assert.equal(meta.testProp, 'testVal');
 
             remove();
             assert.end();
@@ -164,7 +167,9 @@ test('handles throwing strings', function t(assert) {
 
     var remove = uncaught({
         logger: logger,
-        prefix: 'some-server: '
+        meta: {
+            testProp: 'testVal'
+        }
     });
 
     process.nextTick(function throwIt() {
@@ -174,7 +179,7 @@ test('handles throwing strings', function t(assert) {
 
 test('writes to backupFile on error', function t(assert) {
     var logger = {
-        fatal: function fatal(message, error, cb) {
+        fatal: function fatal(message, meta, cb) {
             cb(new Error('cant log'));
         }
     };
@@ -221,7 +226,7 @@ test('writes to backupFile on error', function t(assert) {
 
 test('calls gracefulShutdown', function t(assert) {
     var logger = {
-        fatal: function fatal(message, error, cb) {
+        fatal: function fatal(message, meta, cb) {
             cb(null);
         }
     };
@@ -283,7 +288,7 @@ test('does not write undefined backupFile', function t(assert) {
         throw new Error('test error');
     });
 
-    function fatal(message, error, cb) {
+    function fatal(message, meta, cb) {
         cb(new Error('oops'));
 
         var folders = fs.readdirSync('/');
@@ -296,7 +301,7 @@ test('does not write undefined backupFile', function t(assert) {
 
 test('handles disk failures', function t(assert) {
     var logger = {
-        fatal: function fatal(message, error, cb) {
+        fatal: function fatal(message, meta, cb) {
             cb(new Error('logger error'));
         }
     };

--- a/uncaught.js
+++ b/uncaught.js
@@ -25,7 +25,7 @@ function UncaughtException(options) {
         clearTimeout: options.clearTimeout || globalClearTimeout
     };
 
-    self.prefix = options.prefix ? String(options.prefix) : '';
+    self.meta = options.meta;
     self.backupFile = typeof options.backupFile === 'string' ?
         options.backupFile : null;
     self.statsdKey = typeof options.statsdKey === 'string' ?

--- a/uncaught/uncaught-handler.js
+++ b/uncaught/uncaught-handler.js
@@ -3,6 +3,8 @@
 var process = require('process');
 var domain = require('domain');
 
+var extend = require('xtend');
+
 var tryCatch = require('../lib/try-catch-it.js');
 var errors = require('./errors.js');
 var Constants = require('./constants.js');
@@ -101,16 +103,16 @@ function invokeLoggerFatal() {
     var self = this;
 
     var logger = self.uncaught.logger;
-    var prefix = self.uncaught.prefix;
     var error = self.uncaughtError;
     var type = error.type || '';
+    var meta = extend({
+        type: type,
+        error: error
+    }, self.uncaught.meta);
 
     self.currentState = Constants.LOGGING_ERROR_STATE;
-    logger.fatal(
-        prefix + 'Uncaught Exception: ' + type,
-        error,
-        loggerCallback
-    );
+
+    logger.fatal('Uncaught Exception', meta, loggerCallback);
 
     function loggerCallback(err) {
         self.transition(err);


### PR DESCRIPTION
Chages the log statements to use a static string and provide all information with a meta object in the log statement.

Also note that tests are corrected for the change and fixed to deal with a ulimit configuration difference and exit code difference on mac.

Deps are updated and pruned.