### PR TITLE
capture a full stack trace in uncaught

### DIFF
--- a/uncaught/memory-reporter.js
+++ b/uncaught/memory-reporter.js
@@ -47,6 +47,7 @@ function UncaughtExceptionStruct(stateMachine, states) {
 function UncaughtExceptionStateMachine() {
     this.configValue = null;
     this.uncaughtError = null;
+    this.currentStack = null;
 
     this.transitions = [];
     this.states = {};
@@ -176,6 +177,7 @@ function createStateMachine(error) {
     stateMachine.configValue = self.configValue;
     stateMachine.uncaughtError = error;
     stateMachine.uncaughtErrorType = type;
+    stateMachine.currentStack = new Error('empty').stack;
     ALL_STATES.push(stateMachine);
 
     return stateMachine;


### PR DESCRIPTION
This aids in debugging an uncaught exception through
heap introspection by seeing a full stack trace of
the uncaught callsite rather then just the stack
trace when the Error object is allocated.

r: @shannili @jcorbin