### PR TITLE
logging: Also log errorMessage and errorStack

### DIFF
--- a/uncaught/uncaught-handler.js
+++ b/uncaught/uncaught-handler.js
@@ -107,7 +107,9 @@ function invokeLoggerFatal() {
     var type = error.type || '';
     var meta = extend({
         type: type,
-        error: error
+        error: error,
+        errorMessage: error.message,
+        errorStack: error.stack
     }, self.uncaught.meta);
 
     self.currentState = Constants.LOGGING_ERROR_STATE;


### PR DESCRIPTION
The `error.message` and `error.stack` field are non
enumerable by default, by logging them explicitely
they should always be there.

Duplicating them is better then missing them.

r: @Matt-Esch